### PR TITLE
feat(entity): add TempApplicantEnrolmentDetails JPA entity

### DIFF
--- a/professionaltaxportal/src/main/java/io/example/professionaltaxportal/config/ModelMapperConfig.java
+++ b/professionaltaxportal/src/main/java/io/example/professionaltaxportal/config/ModelMapperConfig.java
@@ -1,0 +1,15 @@
+package io.example.professionaltaxportal.config;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class ModelMapperConfig {
+    
+    @Bean
+    public ModelMapper modelMapper(){
+        return new ModelMapper();
+    }
+}

--- a/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/TempApplicantEnrolmentDetails.java
+++ b/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/TempApplicantEnrolmentDetails.java
@@ -1,0 +1,154 @@
+package io.example.professionaltaxportal.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ttbl_temp_applicant_enrolment", schema = "ptax")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+
+public class TempApplicantEnrolmentDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long rsn;
+
+    @Column(name = "application_id", length = 15)
+    private String applicationid;
+
+    @Column(name = "ptan", length = 10)
+    private String ptan;
+
+    @Column(name = "name", length = 100)
+    private String name;
+
+    @Column(name = "gender", length = 1)
+    private String gender;
+
+    @Column(name = "father_name", length = 100)
+    private String fatherName;
+
+    @Column(name = "mobile", length = 10)
+    private String mobile;
+
+    @Column(name = "email", length = 100)
+    private String email;
+
+    @Column(name = "buisness_name", length = 200)
+    private String buisnessName;
+
+    @Column(name = "jurisdiction_code", length = 3)
+    private String jurisdictionCode;
+
+    @Column(name = "charge_code", length = 4)
+    private String chargeCode;
+
+    @Column(name = "address_text", length = 100)
+    private String addressText;
+
+    @Column(name = "subdistrict_lgd_code")
+    private Integer subdistrictLgdCode;
+
+    @Column(name = "district_lgd_code")
+    private Integer districtLgdCode;
+
+    @Column(name = "pincode", length = 6)
+    private String pincode;
+
+    @Column(name = "ptax_category")
+    private Integer ptaxCategory;
+
+    @Column(name = "ptax_subcategory")
+    private Integer ptaxSubcategory;
+
+    @Column(name = "engaged_with_profession")
+    private Boolean engagedWithProfession;
+
+    @Column(name = "engaged_with_trade")
+    private Boolean engagedWithTrade;
+
+    @Column(name = "engaged_with_calling")
+    private Boolean engagedWithCalling;
+
+    @Column(name = "engaged_with_employement")
+    private Boolean engagedWithEmployment;
+
+    @Column(name = "pan", length = 10)
+    private String pan;
+
+    @Column(name = "inserted_on")
+    private LocalDateTime insertedOn;
+
+    @Column(name = "inserted_by", length = 15)
+    private String insertedBy;
+
+    @Column(name = "inserted_from_ipv4", length = 15)
+    private String insertedFromIpv4;
+
+    @Column(name = "welcome_sms_count")
+    private Integer welcomeSmsCount;
+
+    @Column(name = "welcome_email_count")
+    private Integer welcomeEmailCount;
+
+    @Column(name = "establishment1_name", length = 100)
+    private String establishment1Name;
+
+    @Column(name = "establishment1_address", length = 100)
+    private String establishment1Address;
+
+    @Column(name = "establishment2_name", length = 100)
+    private String establishment2Name;
+
+    @Column(name = "establishment2_address", length = 100)
+    private String establishment2Address;
+
+    @Column(name = "establishment3_name", length = 100)
+    private String establishment3Name;
+
+    @Column(name = "establishment3_address", length = 100)
+    private String establishment3Address;
+
+    @Column(name = "establishment4_name", length = 100)
+    private String establishment4Name;
+
+    @Column(name = "establishment4_address", length = 100)
+    private String establishment4Address;
+
+    @Column(name = "establishment5_name", length = 100)
+    private String establishment5Name;
+
+    @Column(name = "establishment5_address", length = 100)
+    private String establishment5Address;
+
+    @Column(name = "applying_as_individual")
+    private Boolean applyingAsIndividual;
+
+    @Column(name = "status")
+    private Boolean status;
+
+    @Lob
+    @Column(name = "doc_content")
+    private byte[] docContent;
+
+    @Lob
+    @Column(name = "doc_content_trade")
+    private byte[] docContentTrade;
+
+    @Lob
+    @Column(name = "doc_content_death")
+    private byte[] docContentDeath;
+
+    @Column(name = "doc_type", length = 1)
+    private String docType;
+
+    @Column(name = "cancellation_explanation", length = 500)
+    private String cancellationExplanation;
+}
+


### PR DESCRIPTION
**Summary**
This PR introduces a new JPA entity, `TempApplicantEnrolmentDetails`, to capture temporary applicant enrollment data in the `ptax.ttbl_temp_applicant_enrolment` table. It maps all relevant columns for storing applicant information, status flags, and uploaded document contents.

---

### Changes

* **New Entity Class**:

  * `TempApplicantEnrolmentDetails` annotated with `@Entity`, `@Table(name = "ttbl_temp_applicant_enrolment", schema = "ptax")`.
  * Lombok annotations (`@Data`, `@NoArgsConstructor`, `@AllArgsConstructor`) for boilerplate reduction.
* **Field Mappings**:

  * Primary key: `rsn` with `GenerationType.IDENTITY`.
  * String fields for identifiers (`applicationid`, `ptan`), personal data (`name`, `gender`, `fatherName`, `mobile`, `email`, `pan`), and business details (`buisnessName`, `addressText`).
  * Numeric fields for jurisdiction and LGD codes (`subdistrictLgdCode`, `districtLgdCode`), tax categories (`ptaxCategory`, `ptaxSubcategory`), and counters (`welcomeSmsCount`, `welcomeEmailCount`).
  * Boolean flags for engagement types and application status.
  * Five establishment name/address pairs.
  * Timestamp and audit fields for insertion metadata (`insertedOn`, `insertedBy`, `insertedFromIpv4`).
  * Large object (`@Lob`) fields to store document contents (`docContent`, `docContentTrade`, `docContentDeath`).
  * Additional fields for document type and cancellation explanation.

---

### Motivation

* Provide a robust entity representation for temporary enrollment records in the Professional Tax Portal.
* Enable seamless CRUD operations via Spring Data JPA.
* Support storage of both metadata and binary document attachments.
