### PR TITLE
feat(entity): add TempApplicantTradeDetails JPA entity

### DIFF
--- a/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/TempApplicantTradeDetails.java
+++ b/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/TempApplicantTradeDetails.java
@@ -1,0 +1,105 @@
+package io.example.professionaltaxportal.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ttbl_temp_applicant_trade_details", schema = "ptax")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+
+public class TempApplicantTradeDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long rsn;
+
+        @Column(name = "application_id", length = 15)
+    private String applicationId;
+
+    @Column(name = "ptan", length = 10)
+    private String ptan;
+
+    @Column(name = "commencement_date")
+    private LocalDate commencementDate;
+
+    @Column(name = "period_of_standing", length = 50)
+    private String periodOfStanding;
+
+    @Column(name = "pan", length = 10)
+    private String pan;
+
+    @Column(name = "annual_gross_business", precision = 18, scale = 2)
+    private BigDecimal annualGrossBusiness;
+
+    @Column(name = "annual_turn_over", precision = 18, scale = 2)
+    private BigDecimal annualTurnOver;
+
+    @Column(name = "avg_workers_monthly")
+    private Integer avgWorkersMonthly;
+
+    @Column(name = "avg_employees_monthly")
+    private Integer avgEmployeesMonthly;
+
+    @Column(name = "vat_number", length = 11)
+    private String vatNumber;
+
+    @Column(name = "cst_number", length = 11)
+    private String cstNumber;
+
+    @Column(name = "gst_number", length = 15)
+    private String gstNumber;
+
+    @Column(name = "taxi_count")
+    private Integer taxiCount;
+
+    @Column(name = "three_wheeler_count")
+    private Integer threeWheelerCount;
+
+    @Column(name = "lmv_count")
+    private Integer lmvCount;
+
+    @Column(name = "good_vehicle_count")
+    private Integer goodVehicleCount;
+
+    @Column(name = "truck_count")
+    private Integer truckCount;
+
+    @Column(name = "bus_count")
+    private Integer busCount;
+
+    @Column(name = "engaged_with_state_society")
+    private Boolean engagedWithStateSociety;
+
+    @Column(name = "engaged_with_district_society")
+    private Boolean engagedWithDistrictSociety;
+
+    @Column(name = "inserted_on")
+    private LocalDateTime insertedOn;
+
+    @Column(name = "inserted_by", length = 50)
+    private String insertedBy;
+
+    @Column(name = "inserted_from_ipv4", length = 15)
+    private String insertedFromIpv4;
+
+    @Column(name = "updated_on")
+    private LocalDateTime updatedOn;
+
+    @Column(name = "updated_by", length = 50)
+    private String updatedBy;
+
+    @Column(name = "updated_from_ipv4", length = 15)
+    private String updatedFromIpv4;
+
+    @Column(name = "status")
+    private Boolean status;
+    
+}


### PR DESCRIPTION


**Pull Request: Add `TempApplicantTradeDetails` Entity**

**Summary**
This PR introduces a new JPA entity, `TempApplicantTradeDetails`, mapping to the `ptax.ttbl_temp_applicant_trade_details` table. It captures trade-related details for temporary applicants, including business metrics, tax identifiers, vehicle counts, engagement flags, and audit metadata.

---

### Changes

* **New Entity Class**

  * `TempApplicantTradeDetails` annotated with `@Entity` and `@Table(name = "ttbl_temp_applicant_trade_details", schema = "ptax")`.
  * Lombok’s `@Data`, `@NoArgsConstructor`, and `@AllArgsConstructor` to reduce boilerplate.
* **Field Mappings**

  * **Primary key**: `rsn` with `GenerationType.IDENTITY`.
  * Applicant identifiers: `applicationId`, `ptan`, `pan`.
  * Business details: `commencementDate`, `periodOfStanding`, `annualGrossBusiness`, `annualTurnOver`, `avgWorkersMonthly`, `avgEmployeesMonthly`.
  * Tax numbers: `vatNumber`, `cstNumber`, `gstNumber`.
  * Vehicle counts: `taxiCount`, `threeWheelerCount`, `lmvCount`, `goodVehicleCount`, `truckCount`, `busCount`.
  * Engagement flags: `engagedWithStateSociety`, `engagedWithDistrictSociety`.
  * Audit fields: `insertedOn`, `insertedBy`, `insertedFromIpv4`, `updatedOn`, `updatedBy`, `updatedFromIpv4`, and `status`.

---

### Motivation

* Separate trade-specific data from enrollment and profession details for clear domain modeling.
* Facilitate CRUD operations on trade details via Spring Data JPA.
* Ensure consistent storage of both numeric and boolean flags alongside audit timestamps.
