### PR TITLE
feat(entity): add TempApplicantCallingDetails JPA entity

### DIFF
--- a/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/TempApplicantCallingDetails.java
+++ b/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/TempApplicantCallingDetails.java
@@ -1,0 +1,82 @@
+package io.example.professionaltaxportal.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "ttbl_temp_applicant_calling_details", schema = "ptax")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TempApplicantCallingDetails {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long rsn;
+
+    @Column(name = "application_id", length = 15)
+    private String applicationId;
+
+    @Column(name = "ptan", length = 10)
+    private String ptan;
+
+    @Column(name = "commencement_date")
+    private LocalDate commencementDate;
+
+    @Column(name = "period_of_standing", length = 50)
+    private String periodOfStanding;
+
+    @Column(name = "pan", length = 10)
+    private String pan;
+
+    @Column(name = "annual_gross_business", precision = 18, scale = 2)
+    private BigDecimal annualGrossBusiness;
+
+    @Column(name = "avg_workers_monthly")
+    private Integer avgWorkersMonthly;
+
+    @Column(name = "avg_employees_monthly")
+    private Integer avgEmployeesMonthly;
+
+    @Column(name = "vat_number", length = 11)
+    private String vatNumber;
+
+    @Column(name = "cst_number", length = 11)
+    private String cstNumber;
+
+    @Column(name = "gst_number", length = 15)
+    private String gstNumber;
+
+    @Column(name = "engaged_with_state_society")
+    private Boolean engagedWithStateSociety;
+
+    @Column(name = "engaged_with_district_society")
+    private Boolean engagedWithDistrictSociety;
+
+    @Column(name = "inserted_on")
+    private LocalDateTime insertedOn;
+
+    @Column(name = "inserted_by", length = 50)
+    private String insertedBy;
+
+    @Column(name = "inserted_from_ipv4", length = 15)
+    private String insertedFromIpv4;
+
+    @Column(name = "updated_on")
+    private LocalDateTime updatedOn;
+
+    @Column(name = "updated_by", length = 50)
+    private String updatedBy;
+
+    @Column(name = "updated_from_ipv4", length = 15)
+    private String updatedFromIpv4;
+
+    @Column(name = "status")
+    private Boolean status;
+}


### PR DESCRIPTION
**Pull Request: Add `TempApplicantCallingDetails` Entity**

**Summary**
This PR introduces a new JPA entity, `TempApplicantCallingDetails`, mapping to the `ptax.ttbl_temp_applicant_calling_details` table. It captures calling-related details for temporary applicants, including business metrics, tax identifiers, engagement flags, and audit metadata.

---

### Changes

* **New Entity Class**

  * `TempApplicantCallingDetails` annotated with `@Entity` and
    `@Table(name = "ttbl_temp_applicant_calling_details", schema = "ptax")`.
  * Lombok’s `@Data`, `@NoArgsConstructor`, and `@AllArgsConstructor` annotations to reduce boilerplate.
* **Field Mappings**

  * **Primary key**: `rsn` with `GenerationType.IDENTITY`.
  * Applicant identifiers: `applicationId`, `ptan`, `pan`.
  * Business details: `commencementDate`, `periodOfStanding`, `annualGrossBusiness`, `avgWorkersMonthly`, `avgEmployeesMonthly`.
  * Tax numbers: `vatNumber`, `cstNumber`, `gstNumber`.
  * Engagement flags: `engagedWithStateSociety`, `engagedWithDistrictSociety`.
  * Audit fields:

    * `insertedOn`, `insertedBy`, `insertedFromIpv4`
    * `updatedOn`, `updatedBy`, `updatedFromIpv4`
    * `status`

---

### Motivation

* Separate “calling” (service/professional calling) data from enrolment, profession, and trade details for clear domain modeling.
* Enable CRUD operations on calling-specific records using Spring Data JPA.
* Maintain consistency in audit fields and numeric/boolean flag storage across entities.