### PR TITLE
feat(ptax): add District JPA entity for mas_district table

### DIFF
--- a/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/District.java
+++ b/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/District.java
@@ -1,0 +1,25 @@
+package io.example.professionaltaxportal.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Entity
+@Table(name="mas_district", schema = "ptax")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+
+public class District {
+    
+    @Id
+    @Column(name = "district_lgd_code")
+    private Integer districtLgdCode;
+
+    @Column(name = "district_name", length = 50, nullable = false)
+    private String districtName;
+
+    @Column(name = "local_code")
+    private Integer localCode;
+}


### PR DESCRIPTION

This PR introduces the `District` entity class in the `ptax` schema to represent the `mas_district` master table. It models administrative district records with LGD code, name, and local code.

**Key Changes**

* New JPA entity `District` under package `io.example.professionaltaxportal.entity`.
* Mapped to table `mas_district` in the `ptax` schema.
* Fields added:

  * `districtLgdCode` (PK, maps to `district_lgd_code`)
  * `districtName` (maps to `district_name`, length 50, non-nullable)
  * `localCode` (maps to `local_code`)
* Lombok annotations (`@Data`, `@NoArgsConstructor`, `@AllArgsConstructor`) for getters/setters and constructors.
