### PR TITLE
feat(ptax): add Area JPA entity for mtbl_area table

### DIFF
--- a/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/Area.java
+++ b/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/Area.java
@@ -1,0 +1,24 @@
+package io.example.professionaltaxportal.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Entity
+@Table(name = "mtbl_area", schema = "ptax")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Area {
+
+    @Id
+    @Column(name = "code", length = 3)
+    private String code;
+
+    @Column(name = "name_en", length = 50)
+    private String nameEn;
+
+    @Column(name = "name_bn", length = 100)
+    private String nameBn;
+}


### PR DESCRIPTION

This PR adds the `Area` entity class to the `ptax` schema, representing the `mtbl_area` master table. It captures area codes along with English and Bengali names for use in address lookups and form dropdowns.

**Key Changes**

* New JPA entity `Area` under package `io.example.professionaltaxportal.entity`.
* Mapped to table `mtbl_area` in schema `ptax`.
* Fields introduced:

  * `code` (PK, maps to `code`, length 3)
  * `nameEn` (maps to `name_en`, length 50)
  * `nameBn` (maps to `name_bn`, length 100)
* Leveraged Lombok (`@Data`, `@NoArgsConstructor`, `@AllArgsConstructor`) for boilerplate reduction of getters/setters and constructors.
