### PR TITLE
feat(ptax): add Charge JPA entity for mtbl_charge table

### DIFF
--- a/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/Charge.java
+++ b/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/Charge.java
@@ -1,0 +1,27 @@
+package io.example.professionaltaxportal.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Entity
+@Table(name = "mtbl_charge", schema = "ptax")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class Charge {
+
+    @Id
+    @Column(name = "code", length = 4)
+    private String code;
+
+    @Column(name = "charge", length = 255)
+    private String charge;
+
+    @Column(name = "area_code", length = 3)
+    private String areaCode;
+
+    @Column(name = "charge_sn")
+    private Integer chargeSn;
+}


### PR DESCRIPTION
This PR introduces the `Charge` entity class in the `ptax` schema to represent the `mtbl_charge` master table. It models various tax or service charges associated with geographical areas.

**Key Changes**

* Added JPA entity `Charge` under package `io.example.professionaltaxportal.entity`.
* Mapped to table `mtbl_charge` in schema `ptax`.
* Fields include:

  * `code` (PK, maps to `code`, length 4)
  * `charge` (maps to `charge`, length 255)
  * `areaCode` (maps to `area_code`, length 3)
  * `chargeSn` (maps to `charge_sn`, sequence number or ordering index)
* Applied Lombok annotations (`@Data`, `@NoArgsConstructor`, `@AllArgsConstructor`) for boilerplate reduction.
