### PR TITLE
feat(entity): add PTaxCategory JPA entity mapping to mtbl_ptax_category table

### DIFF
--- a/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/PTaxCategory.java
+++ b/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/PTaxCategory.java
@@ -1,0 +1,25 @@
+package io.example.professionaltaxportal.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Entity
+@Table(name = "mtbl_ptax_category", schema = "ptax")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PTaxCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "cat_rsn")
+    private Long catRsn;
+
+    @Column(name = "cat_id")
+    private Integer catId;
+
+    @Column(name = "cat_description", length = 150)
+    private String catDescription;
+}


### PR DESCRIPTION

This PR introduces the `PTaxCategory` JPA entity, which maps to the `ptax.mtbl_ptax_category` table. It provides a simple Java representation of professional tax categories, including fields for the primary key, category ID, and description.

**2. Changes**

* Created `PTaxCategory` class in `io.example.professionaltaxportal.entity` package

  * Annotated with `@Entity` and `@Table(name = "mtbl_ptax_category", schema = "ptax")`
  * Added fields:

    * `catRsn` (`Long`) – primary key, auto-generated (`@Id`, `@GeneratedValue`)
    * `catId` (`Integer`) – category identifier
    * `catDescription` (`String`) – up to 150 characters of descriptive text
  * Used Lombok annotations (`@Data`, `@NoArgsConstructor`, `@AllArgsConstructor`) for boilerplate reduction

**3. Reason**
We need an entity to represent the various professional tax categories stored in the database. This will be used by the service and repository layers to perform CRUD operations on tax categories.
