### PR TITLE
feat(entity): add PTaxCategorySubcategory JPA entity mapping to mtbl_ptax_category_subcategory table

### DIFF
--- a/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/PTaxCategorySubcategory.java
+++ b/professionaltaxportal/src/main/java/io/example/professionaltaxportal/entity/PTaxCategorySubcategory.java
@@ -1,0 +1,34 @@
+package io.example.professionaltaxportal.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Entity
+@Table(name = "mtbl_ptax_category_subcategory", schema = "ptax")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PTaxCategorySubcategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "record_rsn")
+    private Long recordRsn;
+
+    @Column(name = "cat_code")
+    private Integer catCode;
+
+    @Column(name = "cat_description", length = 150)
+    private String catDescription;
+
+    @Column(name = "subcat_code")
+    private Integer subcatCode;
+
+    @Column(name = "subcat_description", length = 150)
+    private String subcatDescription;
+
+    @Column(name = "is_visible")
+    private Integer isVisible;
+}


### PR DESCRIPTION
This PR adds the `PTaxCategorySubcategory` JPA entity, mapping to the `ptax.mtbl_ptax_category_subcategory` table. It models the relationship between professional tax categories and their subcategories, including visibility flags.

**2. Changes**

* Created `PTaxCategorySubcategory` class in `io.example.professionaltaxportal.entity`

  * Annotated with `@Entity` and `@Table(name = "mtbl_ptax_category_subcategory", schema = "ptax")`
  * Added fields:

    * `recordRsn` (`Long`) – primary key, auto-generated via `@GeneratedValue`
    * `catCode` (`Integer`) – foreign key linking to a category code
    * `catDescription` (`String`) – description of the parent category (max length 150)
    * `subcatCode` (`Integer`) – subcategory identifier
    * `subcatDescription` (`String`) – description of the subcategory (max length 150)
    * `isVisible` (`Integer`) – visibility flag (e.g., 1 = visible, 0 = hidden)
  * Utilized Lombok (`@Data`, `@NoArgsConstructor`, `@AllArgsConstructor`) to generate boilerplate

**3. reason**
To support hierarchical tax rules, we need a dedicated entity for category–subcategory mappings. This enables the application to retrieve and manage subcategories alongside their parent categories.
