### PR TITLE
feat(dto): add PersonalDetailsDTO with validation constraints

### DIFF
--- a/professionaltaxportal/src/main/java/io/example/professionaltaxportal/dto/PersonalDetailsDTO.java
+++ b/professionaltaxportal/src/main/java/io/example/professionaltaxportal/dto/PersonalDetailsDTO.java
@@ -1,0 +1,53 @@
+package io.example.professionaltaxportal.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import jakarta.validation.constraints.*;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PersonalDetailsDTO {
+
+    @NotBlank(message = "Name is required")
+    @Size(max = 100, message = "Name cannot exceed 100 characters")
+    private String name;
+
+    @NotBlank(message = "Gender is required")
+    @Pattern(regexp = "[MF]", message = "Gender must be M or F")
+    private String gender;
+
+    @Size(max = 100, message = "Father name cannot exceed 100 characters")
+    private String fatherName;
+
+    @NotBlank(message = "Mobile number is required")
+    @Pattern(regexp = "\\d{10}", message = "Mobile number must be 10 digits")
+    private String mobile;
+
+    @Email(message = "Invalid email format")
+    @Size(max = 100, message = "Email cannot exceed 100 characters")
+    private String email;
+
+    @Size(max = 200, message = "Business name cannot exceed 200 characters")
+    private String businessName;
+
+    @Size(max = 100, message = "Address cannot exceed 100 characters")
+    private String addressText;
+
+    private Integer districtLgdCode;
+
+    @Size(max = 6, message = "Pincode must be 6 digits")
+    @Pattern(regexp = "\\d{6}", message = "Pincode must be 6 digits")
+    private String pincode;
+
+    @Size(max = 10, message = "PAN must be 10 characters")
+    @Pattern(regexp = "[A-Z]{5}[0-9]{4}[A-Z]{1}", message = "Invalid PAN format")
+    private String pan;
+
+    private Boolean applyingAsIndividual;
+
+    private String jurisdictionCode;
+    private String chargeCode;
+}


### PR DESCRIPTION
**1. Summary**
Introduce the `PersonalDetailsDTO` class to encapsulate user personal details for API requests, complete with Jakarta Bean Validation annotations to ensure data integrity.

**2. Changes**

* Created `PersonalDetailsDTO` in `io.example.professionaltaxportal.dto`

  * Annotated with Lombok’s `@Data`, `@NoArgsConstructor`, and `@AllArgsConstructor` for boilerplate reduction
  * Added validation constraints with `javax.validation.constraints`:

    * `name`: required, up to 100 characters (`@NotBlank`, `@Size`)
    * `gender`: required, must be “M” or “F” (`@NotBlank`, `@Pattern`)
    * `fatherName`: optional, up to 100 characters (`@Size`)
    * `mobile`: required, exactly 10 digits (`@NotBlank`, `@Pattern`)
    * `email`: optional, valid email format, up to 100 characters (`@Email`, `@Size`)
    * `businessName`: optional, up to 200 characters (`@Size`)
    * `addressText`: optional, up to 100 characters (`@Size`)
    * `districtLgdCode`: optional integer
    * `pincode`: optional, exactly 6 digits (`@Size`, `@Pattern`)
    * `pan`: optional, valid PAN format (5 letters, 4 digits, 1 letter) (`@Size`, `@Pattern`)
    * `applyingAsIndividual`: optional boolean
    * `jurisdictionCode`, `chargeCode`: optional strings

**3. Reason**
Validation at the DTO layer ensures incoming requests are well-formed before hitting the service or persistence layers, reducing error handling complexity and improving data quality.
