### PR TITLE
feat(dto): add EstablishmentTypeDTO to capture establishment activity types

### DIFF
--- a/professionaltaxportal/src/main/java/io/example/professionaltaxportal/dto/EstablishmentTypeDTO.java
+++ b/professionaltaxportal/src/main/java/io/example/professionaltaxportal/dto/EstablishmentTypeDTO.java
@@ -1,0 +1,19 @@
+package io.example.professionaltaxportal.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class EstablishmentTypeDTO {
+
+    private String applicationId;
+    private Integer ptaxCategory;
+    private Integer ptaxSubcategory;
+    private Boolean engagedWithProfession;
+    private Boolean engagedWithTrade;
+    private Boolean engagedWithCalling;
+    private Boolean engagedWithEmployment;
+}


### PR DESCRIPTION
**1. Summary**
This PR introduces the `EstablishmentTypeDTO` class to represent the types of activities an establishment engages in for a given application. It centralizes category and subcategory selections along with boolean flags indicating engagement in various professional domains.

**2. Changes**

* Added `EstablishmentTypeDTO` in `io.example.professionaltaxportal.dto`

  * `applicationId` (`String`): identifier for the parent application
  * `ptaxCategory` (`Integer`): selected professional tax category code
  * `ptaxSubcategory` (`Integer`): selected subcategory code
  * `engagedWithProfession` (`Boolean`): flag for professional activity
  * `engagedWithTrade` (`Boolean`): flag for trade activity
  * `engagedWithCalling` (`Boolean`): flag for calling activity
  * `engagedWithEmployment` (`Boolean`): flag for employment activity
* Applied Lombok annotations (`@Data`, `@NoArgsConstructor`, `@AllArgsConstructor`) for automatic generation of boilerplate

**3. Reason**
Different establishments may engage in multiple professional domains under the professional tax regime. This DTO provides a clear, single-structure payload to capture an establishment’s selected tax category/subcategory and its engagement flags in one API request or response.