### PR TITLE
feat(dto): add ProfessionDetailsDTO for profession-specific details

### DIFF
--- a/professionaltaxportal/src/main/java/io/example/professionaltaxportal/dto/ProfessionDetailsDTO.java
+++ b/professionaltaxportal/src/main/java/io/example/professionaltaxportal/dto/ProfessionDetailsDTO.java
@@ -1,0 +1,33 @@
+package io.example.professionaltaxportal.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProfessionDetailsDTO {
+
+    private String applicationId;
+    private LocalDate commencementDate;
+    private String periodOfStanding;
+    private String pan;
+    private BigDecimal annualGrossBusiness;
+    private Integer avgWorkersMonthly;
+    private Integer avgEmployeesMonthly;
+    private String vatNumber;
+    private String cstNumber;
+    private String gstNumber;
+    private Integer taxiCount;
+    private Integer threeWheelerCount;
+    private Integer lmvCount;
+    private Integer goodVehicleCount;
+    private Integer truckCount;
+    private Integer busCount;
+    private Boolean engagedWithStateSociety;
+    private Boolean engagedWithDistrictSociety;
+}


### PR DESCRIPTION
**1. Summary**
This PR introduces the `ProfessionDetailsDTO` class to capture detailed profession-related information for a given application. It includes business metrics, tax identifiers, vehicle counts, and engagement flags with local societies.

**2. Changes**

* Created `ProfessionDetailsDTO` in `io.example.professionaltaxportal.dto`

  * Fields:

    * `applicationId` (`String`): ties details to the parent application
    * `commencementDate` (`LocalDate`): date when the profession commenced
    * `periodOfStanding` (`String`): duration the profession has been in operation
    * `pan` (`String`): Permanent Account Number
    * `annualGrossBusiness` (`BigDecimal`): annual gross business turnover
    * `avgWorkersMonthly` (`Integer`): average number of workers per month
    * `avgEmployeesMonthly` (`Integer`): average number of employees per month
    * `vatNumber`, `cstNumber`, `gstNumber` (`String`): various tax identifiers
    * Vehicle counts (`Integer`): `taxiCount`, `threeWheelerCount`, `lmvCount`, `goodVehicleCount`, `truckCount`, `busCount`
    * Engagement flags (`Boolean`): `engagedWithStateSociety`, `engagedWithDistrictSociety`
* Applied Lombok’s `@Data`, `@NoArgsConstructor`, and `@AllArgsConstructor` to generate getters/setters, constructors, and `toString`/`equals`/`hashCode`.

**3.Reason**
This DTO consolidates all profession-specific data points in one structure, enabling service and controller layers to handle complex business and regulatory information in a single payload.
