### PR TITLE
feat(dto): introduce TradeDetailsDTO for trade-specific tax details

### DIFF
--- a/professionaltaxportal/src/main/java/io/example/professionaltaxportal/dto/TradeDetailsDTO.java
+++ b/professionaltaxportal/src/main/java/io/example/professionaltaxportal/dto/TradeDetailsDTO.java
@@ -1,0 +1,34 @@
+package io.example.professionaltaxportal.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TradeDetailsDTO {
+
+    private String applicationId;
+    private LocalDate commencementDate;
+    private String periodOfStanding;
+    private String pan;
+    private BigDecimal annualGrossBusiness;
+    private BigDecimal annualTurnOver;
+    private Integer avgWorkersMonthly;
+    private Integer avgEmployeesMonthly;
+    private String vatNumber;
+    private String cstNumber;
+    private String gstNumber;
+    private Integer taxiCount;
+    private Integer threeWheelerCount;
+    private Integer lmvCount;
+    private Integer goodVehicleCount;
+    private Integer truckCount;
+    private Integer busCount;
+    private Boolean engagedWithStateSociety;
+    private Boolean engagedWithDistrictSociety;
+}


### PR DESCRIPTION
**1. Background**
In order to capture industry‑specific information for professional tax submissions, we need a dedicated data transfer object (DTO) that extends beyond general profession details. The existing `ProfessionDetailsDTO` covers business turnover and workforce size, but does not account for trade‑related fields such as vehicle counts or indirect‑tax registration numbers.

**2. What’s Changed**

* **New DTO**: Added `TradeDetailsDTO` in `io.example.professionaltaxportal.dto`.
* **Fields included**:

  * **Identifiers & Dates**

    * `applicationId` (String)
    * `commencementDate` (LocalDate)
    * `periodOfStanding` (String)
    * `pan` (String)
  * **Financials**

    * `annualGrossBusiness` (BigDecimal)
    * `annualTurnOver` (BigDecimal)
  * **Workforce Metrics**

    * `avgWorkersMonthly` (Integer)
    * `avgEmployeesMonthly` (Integer)
  * **Tax Registrations**

    * `vatNumber`, `cstNumber`, `gstNumber` (String)
  * **Vehicle Counts**

    * `taxiCount`, `threeWheelerCount`, `lmvCount`, `goodVehicleCount`, `truckCount`, `busCount` (Integer)
  * **Society Engagement**

    * `engagedWithStateSociety`, `engagedWithDistrictSociety` (Boolean)

All fields are annotated with Lombok’s `@Data`, `@NoArgsConstructor`, and `@AllArgsConstructor` to auto‑generate getters, setters, constructors, `equals()`, `hashCode()`, and `toString()`.

