### PR TITLE
feat(repository): add TempApplicantProfessionalDetailsRepository - Create JpaRepository interface for TempApplicantProfessionDetails entity - Add query method: • findByApplicationId(String applicationId) - Add delete operation: • deleteByApplicationId(String applicationId)

### DIFF
--- a/professionaltaxportal/src/main/java/io/example/professionaltaxportal/repository/TempApplicantProfessionalDetailsRepository.java
+++ b/professionaltaxportal/src/main/java/io/example/professionaltaxportal/repository/TempApplicantProfessionalDetailsRepository.java
@@ -1,0 +1,16 @@
+package io.example.professionaltaxportal.repository;
+
+import io.example.professionaltaxportal.entity.TempApplicantProfessionDetails;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+
+@Repository
+public interface TempApplicantProfessionalDetailsRepository extends 
+JpaRepository<TempApplicantProfessionDetails, Long> {
+    Optional<TempApplicantProfessionDetails> findByApplicationId(String applicationId);
+    void deleteByApplicationId(String applicationId);
+
+}


### PR DESCRIPTION
**Pull Request Description**

**Summary**
This PR introduces a new Spring Data JPA repository interface, `TempApplicantProfessionalDetailsRepository`, to manage persistence for the `TempApplicantProfessionDetails` entity. It exposes methods to retrieve and delete professional details by application ID.

**Changes**

* **New Repository Interface**

  ```java
  public interface TempApplicantProfessionalDetailsRepository 
      extends JpaRepository<TempApplicantProfessionDetails, Long> {

      Optional<TempApplicantProfessionDetails> findByApplicationId(String applicationId);
      void deleteByApplicationId(String applicationId);
  }
  ```
* **Exposed Methods**

  1. `Optional<TempApplicantProfessionDetails> findByApplicationId(String applicationId)`
  2. `void deleteByApplicationId(String applicationId)`

**Reason**
We need a dedicated repository to:

* Retrieve a temporary applicant’s professional details by their application ID.
* Clean up (delete) those details when an application is withdrawn or completed.